### PR TITLE
Add support for gzipped torrent search results

### DIFF
--- a/config-sample.php
+++ b/config-sample.php
@@ -10,7 +10,7 @@ define('SQLITE_FILENAME', 'database.sqlite3');
 define('LETTERBOXD_USERNAME', ''); /* write your username here */
 define('LETTERBOXD_URL', 'http://letterboxd.com/' . LETTERBOXD_USERNAME . '/watchlist/');
 
-define('KICKASSTORRENT_URL', 'http://kickass.to/usearch/category:movies%20');
+define('KICKASSTORRENT_URL', 'https://kat.cr/usearch/category:movies%20');
 
 define('LIMIT_FIND_NOT_SEARCHED_YET', 10);
 define('LIMIT_FIND_NOT_FOUND_YET', 10);

--- a/cron.php
+++ b/cron.php
@@ -68,6 +68,17 @@ function searchForTorrent(PDO $pdo, $titleWhitelist, $titleBlacklist, $films) {
 
     foreach ($films as $film) {
         $site = file_get_contents(KICKASSTORRENT_URL . rawurlencode($film->title) . '/?rss=1');
+		
+		// If http response header mentions that content is gzipped, then uncompress it
+		foreach($http_response_header as $c => $h)
+		{
+			if(stristr($h, 'content-encoding') and stristr($h, 'gzip'))
+			{
+				// Now lets uncompress the compressed data
+				$site = gzinflate( substr($site, 10, -8) );
+			}
+		}
+		
         $siteDecoded = html_entity_decode($site);
         if ($site === false || trim($siteDecoded) === '') {
             $updateSearchedStatement->bindParam(':title', $film->title);


### PR DESCRIPTION
kat.cr now always returns gzipped content, regardless of requested encoding.

Used code from:
http://www.binarytides.com/php-fetch-gzipped-content-over-http-with-file_get_contents/

More solutions and info:
http://stackoverflow.com/questions/8895852/uncompress-gzip-compressed-http-response
http://digitalpbk.com/php/file_get_contents-garbled-gzip-encoding-website-scraping
